### PR TITLE
Add advanced optimiser and notebook

### DIFF
--- a/notebooks/approximation_exploration.ipynb
+++ b/notebooks/approximation_exploration.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1efaefc7",
+   "metadata": {},
+   "source": [
+    "# Exponential approximation exploration\n",
+    "\n",
+    "This notebook demonstrates the quality of the sum of exponentials approximation implemented in the library."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c8ed25c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "from kl_decomposition import gauss_legendre_rule, fit_exp_sum"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85865d4a",
+   "metadata": {},
+   "source": [
+    "## Helper utilities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2971c9a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def l2_error(f, g, x, w):\n",
+    "    return np.sqrt(np.sum(w * (f(x) - g(x))**2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b69930a0",
+   "metadata": {},
+   "source": [
+    "## Target covariance functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17237d2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def cov_exp(d):\n",
+    "    return np.exp(-d)\n",
+    "\n",
+    "def cov_matern32(d):\n",
+    "    return (1 + d) * np.exp(-d)\n",
+    "\n",
+    "def cov_matern52(d):\n",
+    "    return (1 + d + d**2/3.) * np.exp(-d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "762460dc",
+   "metadata": {},
+   "source": [
+    "## Fit and error curves"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8969e94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "x, w = gauss_legendre_rule(0.0, 5.0, 200)\n",
+    "funcs = {\n",
+    "    'Exponential': cov_exp,\n",
+    "    'Matern 3/2': cov_matern32,\n",
+    "    'Matern 5/2': cov_matern52,\n",
+    "}\n",
+    "errors = {name: [] for name in funcs}\n",
+    "ns = range(1, 7)\n",
+    "for n in ns:\n",
+    "    for name, f in funcs.items():\n",
+    "        a, b = fit_exp_sum(n, x, w, f, method='de')\n",
+    "        def approx(t, a=a, b=b):\n",
+    "            return np.sum(a[:, None] * np.exp(-b[:, None] * t[None, :]**2), axis=0)\n",
+    "        err = l2_error(f, approx, x, w)\n",
+    "        errors[name].append(err)\n",
+    "plt.figure(figsize=(6,4))\n",
+    "for name, vals in errors.items():\n",
+    "    plt.semilogy(list(ns), vals, label=name)\n",
+    "plt.xlabel('Number of terms')\n",
+    "plt.ylabel('L2 error')\n",
+    "plt.legend()\n",
+    "plt.tight_layout()\n"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/kl_decomposition/__init__.py
+++ b/src/kl_decomposition/__init__.py
@@ -1,10 +1,19 @@
 """KL decomposition utilities."""
 
-from .kernel_fit import rectangle_rule, gauss_legendre_rule, fit_exp_sum, OptimiserOptions
+from .kernel_fit import (
+    rectangle_rule,
+    gauss_legendre_rule,
+    fit_exp_sum,
+    OptimiserOptions,
+    newton_with_line_search,
+    bisection_line_search,
+)
 
 __all__ = [
     "rectangle_rule",
     "gauss_legendre_rule",
     "fit_exp_sum",
     "OptimiserOptions",
+    "newton_with_line_search",
+    "bisection_line_search",
 ]

--- a/tests/test_kernel_fit.py
+++ b/tests/test_kernel_fit.py
@@ -1,10 +1,20 @@
+import unittest
 import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from kl_decomposition import rectangle_rule, fit_exp_sum
 
 
-def test_fit_single_exp():
-    x, w = rectangle_rule(0.0, 2.0, 50)
-    f = lambda t: 2.0 * np.exp(-3.0 * t ** 2)
-    a, b = fit_exp_sum(1, x, w, f)
-    assert np.allclose(a, 2.0, rtol=1e-2, atol=1e-2)
-    assert np.allclose(b, 3.0, rtol=1e-2, atol=1e-2)
+class TestKernelFit(unittest.TestCase):
+    def test_fit_single_exp(self):
+        x, w = rectangle_rule(0.0, 2.0, 50)
+        f = lambda t: 2.0 * np.exp(-3.0 * t ** 2)
+        a, b = fit_exp_sum(1, x, w, f, method="de")
+        self.assertTrue(np.allclose(a, 2.0, rtol=1e-2, atol=1e-2))
+        self.assertTrue(np.allclose(b, 3.0, rtol=1e-2, atol=1e-2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add JAX based Newton optimisation with bisection line search
- implement differential evolution with optional Newton refinement
- expose new utilities in package API
- convert tests to `unittest` style and update to new API
- provide exploration notebook of approximation quality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403dee0a9c83238e31d7ea719d051d