### PR TITLE
Add jit compilation and benchmark notebook

### DIFF
--- a/notebooks/benchmark.ipynb
+++ b/notebooks/benchmark.ipynb
@@ -1,0 +1,115 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "448efce8",
+   "metadata": {},
+   "source": [
+    "# Benchmarking JIT compilation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c558557f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.insert(0, str(Path('..') / 'src'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7a4feb42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from kl_decomposition import rectangle_rule, fit_exp_sum\n",
+    "from kl_decomposition.kernel_fit import _prepare_jax_funcs, _objective, _objective_jax"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ccf6efed",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x, w = rectangle_rule(0.0, 2.0, 100)\n",
+    "func = lambda t: np.exp(-3.0*t**2)\n",
+    "target = func(x)\n",
+    "params = np.zeros(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01ec61fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from jax import numpy as jnp\n",
+    "params_j = jnp.array(params)\n",
+    "x_j = jnp.array(x)\n",
+    "target_j = jnp.array(target)\n",
+    "w_j = jnp.array(w)\n",
+    "_objective_jax(params_j, x_j, target_j, w_j, 1).block_until_ready()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e7fc1e85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit\n",
+    "_objective_jax(params_j, x_j, target_j, w_j, 1).block_until_ready()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27932a19",
+   "metadata": {
+    "tags": [
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# warm up numba\n",
+    "_objective(params, x, target, w, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d03c9735",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit\n",
+    "_objective(params, x, target, w, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28a54faa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit\n",
+    "fit_exp_sum(1, x, w, func, method='de_newton')"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- speed up kernel fitting with `numba` and `jax.jit`
- use gradient direction when Hessian solve fails
- include simple benchmark notebook for jit timings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684047152f348323a08c60cb1b7a36f7