### PR TITLE
Fix JAX objective slicing

### DIFF
--- a/src/kl_decomposition/kernel_fit.py
+++ b/src/kl_decomposition/kernel_fit.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Callable, Iterable, Tuple, Literal
+import functools
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -84,7 +85,7 @@ class OptimiserOptions:
     local_options: dict | None = None
 
 
-@jax.jit
+@functools.partial(jax.jit, static_argnums=(4,))
 def _objective_jax(
     params: jnp.ndarray,
     d: jnp.ndarray,

--- a/tests/test_kernel_fit.py
+++ b/tests/test_kernel_fit.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from kl_decomposition import rectangle_rule, fit_exp_sum
+from kl_decomposition.kernel_fit import _objective_jax
+import jax.numpy as jnp
 
 
 class TestKernelFit(unittest.TestCase):
@@ -14,6 +16,14 @@ class TestKernelFit(unittest.TestCase):
         a, b = fit_exp_sum(1, x, w, f, method="de")
         self.assertTrue(np.allclose(a, 2.0, rtol=1e-2, atol=1e-2))
         self.assertTrue(np.allclose(b, 3.0, rtol=1e-2, atol=1e-2))
+
+    def test_objective_jax_static_indexing(self):
+        params = jnp.zeros(2)
+        x = jnp.linspace(0.0, 1.0, 5)
+        w = jnp.ones_like(x)
+        target = jnp.exp(-3.0 * x ** 2)
+        val = _objective_jax(params, x, target, w, 1)
+        self.assertIsInstance(float(val.block_until_ready()), float)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix `_objective_jax` to treat `n_terms` as a static argument
- add regression test for the JAX objective

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404be25b6c8323807409730486eb66