### PR TITLE
Add Newton LS demo and debugging info

### DIFF
--- a/notebooks/newton_exp_fit_demo.ipynb
+++ b/notebooks/newton_exp_fit_demo.ipynb
@@ -1,0 +1,33 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Newton line search on exponential fit"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "import sys\nfrom pathlib import Path\nsys.path.insert(0, str(Path('..') / 'src'))\nfrom kl_decomposition import rectangle_rule, fit_exp_sum, newton_with_line_search\nfrom kl_decomposition.kernel_fit import _prepare_jax_funcs\nimport numpy as np\nimport jax\nimport jax.numpy as jnp"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "N = 3\nx, w = rectangle_rule(0.0, 5.0, 100)\nfunc = lambda t: np.exp(-t)\na_ls, b_ls, info = fit_exp_sum(N, x, w, func, method='de_ls', max_gen=5, pop_size=10, return_info=True)\nprint('initial a:', a_ls)\nprint('initial b:', b_ls)"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": "target = func(x)\nobj, grad, hess = _prepare_jax_funcs(x, target, w, N)\nparams0 = np.log(np.concatenate([a_ls, b_ls]))\nparams_opt, stats = newton_with_line_search(params0, obj, grad, hess, max_iter=10, return_stats=True)\nprint('refined a:', np.exp(params_opt[:N]))\nprint('refined b:', np.exp(params_opt[N:]))\nprint('Newton iterations:', stats.iterations)"
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add `newton_exp_fit_demo.ipynb` showing Newton line search for fitting `exp(-d)`
- extend `bisection_line_search` to report iteration count
- print debug info from `newton_with_line_search` and fall back to gradient steps when necessary

## Testing
- `pip install numpy scipy jaxlib jax numba`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410e41c1a8832382e2904366f57d07