### PR TITLE
Add noncompiled solver variant

### DIFF
--- a/tests/test_kernel_fit.py
+++ b/tests/test_kernel_fit.py
@@ -25,6 +25,13 @@ class TestKernelFit(unittest.TestCase):
         val = _objective_jax(params, x, target, w, 1)
         self.assertIsInstance(float(val.block_until_ready()), float)
 
+    def test_de_newton_one_step_nocompile(self):
+        x, w = rectangle_rule(0.0, 1.0, 20)
+        f = lambda t: 1.0 * np.exp(-2.0 * t ** 2)
+        a, b = fit_exp_sum(1, x, w, f, method="de_newton1", compiled=False)
+        self.assertEqual(len(a), 1)
+        self.assertEqual(len(b), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow turning off JIT compilation in `fit_exp_sum`
- add single-step Newton option `de_newton1`
- provide finite-difference derivatives when JIT is disabled
- print Newton information on a single line
- expose default DE population parameters
- test noncompiled mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411b3293f8832385d2ff021496c296