### PR TITLE
Fix DE defaults and add no-JIT demo

### DIFF
--- a/notebooks/newton_exp_fit_demo_nocompile.ipynb
+++ b/notebooks/newton_exp_fit_demo_nocompile.ipynb
@@ -1,0 +1,39 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "# Newton line search on exponential fit (no JIT)"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "import sys\nfrom pathlib import Path\nsys.path.insert(0, str(Path('..') / 'src'))\nfrom kl_decomposition import rectangle_rule, fit_exp_sum, newton_with_line_search\nfrom kl_decomposition.kernel_fit import _prepare_numpy_funcs\nimport numpy as np"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "N = 3\nx, w = rectangle_rule(0.0, 5.0, 100)\nfunc = lambda t: np.exp(-t)\na_ls, b_ls, info = fit_exp_sum(N, x, w, func, method='de_ls', compiled=False, max_gen=5, pop_size=10, return_info=True)\nprint('initial a:', a_ls)\nprint('initial b:', b_ls)"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "target = func(x)\nobj, grad, hess = _prepare_numpy_funcs(x, target, w, N)\nparams0 = np.log(np.concatenate([a_ls, b_ls]))\nparams_opt, stats = newton_with_line_search(params0, obj, grad, hess, max_iter=10, compiled=False, return_stats=True)\nprint('refined a:', np.exp(params_opt[:N]))\nprint('refined b:', np.exp(params_opt[N:]))\nprint('Newton iterations:', stats.iterations)"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python",
+      "language": "python",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/src/kl_decomposition/kernel_fit.py
+++ b/src/kl_decomposition/kernel_fit.py
@@ -372,8 +372,8 @@ def fit_exp_sum(
     max_gen: int = 100,
     pop_size: int = 15,
     n_newton: int = 2,
-    de_mean: ArrayLike = 1.0,
-    de_sigma: ArrayLike = 1.0,
+    de_mean: ArrayLike | None = None,
+    de_sigma: ArrayLike | None = None,
     newton_max_iter: int = 10,
     compiled: bool = True,
     return_info: bool = False,
@@ -405,7 +405,8 @@ def fit_exp_sum(
         when ``method='de_newton'``.
     de_mean, de_sigma : array_like, optional
         Mean and standard deviation for the initial population of the
-        differential evolution. Defaults to ``1``.
+        differential evolution. If not provided, arrays of ones are used
+        (length ``2*N`` for the standard methods and ``N`` for ``'de_ls'``).
     newton_max_iter : int, optional
         Maximum Newton iterations when ``method='de_newton'``.
     compiled : bool, optional
@@ -429,6 +430,15 @@ def fit_exp_sum(
     opt = optimiser or OptimiserOptions()
 
     bounds = [(-5.0, 5.0)] * (2 * n_terms)
+
+    if de_mean is None:
+        de_mean = np.ones(n_terms if method == "de_ls" else 2 * n_terms)
+    else:
+        de_mean = np.asarray(de_mean, dtype=float)
+    if de_sigma is None:
+        de_sigma = np.ones_like(de_mean)
+    else:
+        de_sigma = np.asarray(de_sigma, dtype=float)
 
     objective_fn = _objective if compiled else _objective_py
 


### PR DESCRIPTION
## Summary
- fix `fit_exp_sum` default parameters for DE initialisation
- add notebook demonstrating Newton optimisation without JIT

## Testing
- `pip install numpy jax jaxlib scipy numba --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411d78769083238a8d3bd3c5b9344c