### PR TITLE
Refactor optimisation interface

### DIFF
--- a/notebooks/approximation_exploration.ipynb
+++ b/notebooks/approximation_exploration.ipynb
@@ -104,7 +104,7 @@
     "ns = range(1, 7)\n",
     "for n in ns:\n",
     "    for name, f in funcs.items():\n",
-    "        a, b = fit_exp_sum(n, x, w, f, method='de')\n",
+  "        a, b, _ = fit_exp_sum(n, x, w, f, method='de')\n",
     "        def approx(t, a=a, b=b):\n",
     "            return np.sum(a[:, None] * np.exp(-b[:, None] * t[None, :]**2), axis=0)\n",
     "        err = l2_error(f, approx, x, w)\n",

--- a/notebooks/benchmark.ipynb
+++ b/notebooks/benchmark.ipynb
@@ -29,7 +29,7 @@
    "source": [
     "import numpy as np\n",
     "from kl_decomposition import rectangle_rule, fit_exp_sum\n",
-    "from kl_decomposition.kernel_fit import _prepare_jax_funcs, _objective, _objective_jax"
+  "from kl_decomposition.kernel_fit import _prepare_jax_funcs, _objective_de, _objective_jax_de"
    ]
   },
   {
@@ -52,12 +52,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from jax import numpy as jnp\n",
-    "params_j = jnp.array(params)\n",
-    "x_j = jnp.array(x)\n",
-    "target_j = jnp.array(target)\n",
-    "w_j = jnp.array(w)\n",
-    "_objective_jax(params_j, x_j, target_j, w_j, 1).block_until_ready()"
+  "from jax import numpy as jnp\n",
+  "params_j = jnp.array(params)\n",
+  "x_j = jnp.array(x)\n",
+  "target_j = jnp.array(target)\n",
+  "w_j = jnp.array(w)\n",
+  "_objective_jax_de(params_j, x_j, target_j, w_j, 1).block_until_ready()"
    ]
   },
   {
@@ -67,8 +67,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%timeit\n",
-    "_objective_jax(params_j, x_j, target_j, w_j, 1).block_until_ready()"
+  "%%timeit\n",
+  "_objective_jax_de(params_j, x_j, target_j, w_j, 1).block_until_ready()"
    ]
   },
   {
@@ -82,8 +82,8 @@
    },
    "outputs": [],
    "source": [
-    "# warm up numba\n",
-    "_objective(params, x, target, w, 1)"
+  "# warm up numba\n",
+  "_objective_de(params, x, target, w, 1)"
    ]
   },
   {
@@ -93,8 +93,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%timeit\n",
-    "_objective(params, x, target, w, 1)"
+  "%%timeit\n",
+  "_objective_de(params, x, target, w, 1)"
    ]
   },
   {

--- a/notebooks/de_ls_demo.ipynb
+++ b/notebooks/de_ls_demo.ipynb
@@ -1,1 +1,32 @@
-{"cells": [{"cell_type": "markdown", "metadata": {}, "source": "# Differential evolution with least squares"}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": "import sys\nfrom pathlib import Path\nsys.path.insert(0, str(Path('..') / 'src'))\nfrom kl_decomposition import rectangle_rule, fit_exp_sum\nimport numpy as np"}, {"cell_type": "code", "metadata": {}, "execution_count": null, "outputs": [], "source": "x, w = rectangle_rule(0.0, 2.0, 50)\nf = lambda t: 2.0 * np.exp(-3.0 * t**2) + 0.5 * np.exp(-1.0 * t**2)\na, b, info = fit_exp_sum(2, x, w, f, method='de_ls', max_gen=20, pop_size=20, return_info=True)\nprint('a:', a)\nprint('b:', b)\nprint('iterations:', info.iterations)\nprint('best_score:', info.best_score)"}], "metadata": {"kernelspec": {"display_name": "Python", "language": "python", "name": "python3"}}, "nbformat": 4, "nbformat_minor": 2}
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": "# Differential evolution with least squares"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "import sys\nfrom pathlib import Path\nsys.path.insert(0, str(Path('..') / 'src'))\nfrom kl_decomposition import rectangle_rule, fit_exp_sum\nimport numpy as np"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": "x, w = rectangle_rule(0.0, 2.0, 50)\nf = lambda t: 2.0 * np.exp(-3.0 * t**2) + 0.5 * np.exp(-1.0 * t**2)\na, b, info = fit_exp_sum(2, x, w, f, method=\"de_ls\", max_gen=20, pop_size=20)\nprint(\"a:\", a)\nprint(\"b:\", b)\nprint(\"iterations:\", info.iterations)\nprint(\"best_score:\", info.best_score)"
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python",
+      "language": "python",
+      "name": "python3"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/notebooks/newton_exp_fit_demo.ipynb
+++ b/notebooks/newton_exp_fit_demo.ipynb
@@ -32,7 +32,7 @@
     "N = 4\n",
     "x, w = rectangle_rule(0.0, 5.0, 100)\n",
     "func = lambda t: np.exp(-t)\n",
-    "a_ls, b_ls, info = fit_exp_sum(N, x, w, func, method='de_ls', max_gen=500, pop_size=30, return_info=True)\n",
+  "a_ls, b_ls, info = fit_exp_sum(N, x, w, func, method='de_ls', max_gen=500, pop_size=30)\n",
     "print('initial a:', a_ls)\n",
     "print('initial b:', b_ls)\n"
    ]
@@ -44,9 +44,9 @@
    "outputs": [],
    "source": [
     "target = func(x)\n",
-    "obj, grad, hess = _prepare_jax_funcs(x, target, w, N)\n",
-    "params0 = np.log(np.concatenate([a_ls, b_ls]))\n",
-    "params_opt, stats = newton_with_line_search(params0, obj, grad, hess, max_iter=10, return_stats=True)\n",
+  "obj, grad, hess = _prepare_jax_funcs(x, target, w, N, newton=True)\n",
+  "params0 = np.concatenate([a_ls, np.log(b_ls)])\n",
+  "params_opt, stats = newton_with_line_search(params0, obj, grad, hess, max_iter=10)\n",
     "print('refined a:', np.exp(params_opt[:N]))\n",
     "print('refined b:', np.exp(params_opt[N:]))\n",
     "print('Newton iterations:', stats.iterations)"

--- a/notebooks/newton_exp_fit_demo_nocompile.ipynb
+++ b/notebooks/newton_exp_fit_demo_nocompile.ipynb
@@ -37,8 +37,8 @@
         "    print(f'Fitting with N={N}')\n",
         "    init_means = np.hstack([b_ls, b_ls[-1]**2 / b_ls[-2]])\n",
         "    init_sigmas = np.ones((N,))\n",
-        "    a_ls, b_ls, info = fit_exp_sum(N, x, w, func, method='de_ls', compiled=False, \n",
-        "                                   max_gen=100, pop_size=20, return_info=True, de_mean=init_means, de_sigma=init_sigmas)\n",
+  "    a_ls, b_ls, info = fit_exp_sum(N, x, w, func, method='de_ls', compiled=False, \n",
+  "                                   max_gen=100, pop_size=20, de_mean=init_means, de_sigma=init_sigmas)\n",
         "    print('initial a:', a_ls)\n",
         "    print('initial b:', b_ls)"
       ]
@@ -50,9 +50,9 @@
       "outputs": [],
       "source": [
         "target = func(x)\n",
-        "obj, grad, hess = _prepare_numpy_funcs(x, target, w, N)\n",
-        "params0 = np.log(np.concatenate([a_ls, b_ls]))\n",
-        "params_opt, stats = newton_with_line_search(params0, obj, grad, hess, max_iter=100, compiled=False, return_stats=True, tol=1e-9)\n",
+  "obj, grad, hess = _prepare_numpy_funcs(x, target, w, N, newton=True)\n",
+  "params0 = np.concatenate([a_ls, np.log(b_ls)])\n",
+  "params_opt, stats = newton_with_line_search(params0, obj, grad, hess, max_iter=100, compiled=False)\n",
         "print('refined a:', np.exp(params_opt[:N]))\n",
         "print('refined b:', np.exp(params_opt[N:]))\n",
         "print('Newton iterations:', stats.iterations)"

--- a/tests/test_kernel_fit.py
+++ b/tests/test_kernel_fit.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from kl_decomposition import rectangle_rule, fit_exp_sum
-from kl_decomposition.kernel_fit import _objective_jax
+from kl_decomposition.kernel_fit import _objective_jax_de
 import jax.numpy as jnp
 
 
@@ -13,7 +13,7 @@ class TestKernelFit(unittest.TestCase):
     def test_fit_single_exp(self):
         x, w = rectangle_rule(0.0, 2.0, 50)
         f = lambda t: 2.0 * np.exp(-3.0 * t ** 2)
-        a, b = fit_exp_sum(1, x, w, f, method="de")
+        a, b, _ = fit_exp_sum(1, x, w, f, method="de")
         self.assertTrue(np.allclose(a, 2.0, rtol=1e-2, atol=1e-2))
         self.assertTrue(np.allclose(b, 3.0, rtol=1e-2, atol=1e-2))
 
@@ -22,13 +22,13 @@ class TestKernelFit(unittest.TestCase):
         x = jnp.linspace(0.0, 1.0, 5)
         w = jnp.ones_like(x)
         target = jnp.exp(-3.0 * x ** 2)
-        val = _objective_jax(params, x, target, w, 1)
+        val = _objective_jax_de(params, x, target, w, 1)
         self.assertIsInstance(float(val.block_until_ready()), float)
 
     def test_de_newton_one_step_nocompile(self):
         x, w = rectangle_rule(0.0, 1.0, 20)
         f = lambda t: 1.0 * np.exp(-2.0 * t ** 2)
-        a, b = fit_exp_sum(1, x, w, f, method="de_newton1", compiled=False)
+        a, b, _ = fit_exp_sum(1, x, w, f, method="de_newton1", compiled=False)
         self.assertEqual(len(a), 1)
         self.assertEqual(len(b), 1)
 


### PR DESCRIPTION
## Summary
- overhaul objective functions for clearer parameterisation
- refactor Newton and differential evolution routines
- update API to always return optimisation stats
- clean notebooks and tests for the new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417febe42c8323a6c958ff858a1750