### PR TITLE
Add convergence demo notebook

### DIFF
--- a/notebooks/convergence_demo_nocompile.ipynb
+++ b/notebooks/convergence_demo_nocompile.ipynb
@@ -1,0 +1,93 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": ["# Convergence of exponential approximation","\n","\n","Fitting $e^{-d}$ on $(0,2)$ with sums of Gaussians using differential evolution with least squares followed by Newton refinement."]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.insert(0, str(Path('..') / 'src'))\n",
+    "\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from kl_decomposition import gauss_legendre_rule, fit_exp_sum, newton_with_line_search\n",
+    "from kl_decomposition.kernel_fit import _prepare_numpy_funcs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def l2_error(f, g, x, w):\n",
+    "    return np.sqrt(np.sum(w * (f(x) - g(x))**2))\n",
+    "\n",
+    "x, w = gauss_legendre_rule(0.0, 2.0, 1000)\n",
+    "f = lambda t: np.exp(-t)\n",
+    "\n",
+    "errors = []\n",
+    "a_prev = None\n",
+    "b_prev = None\n",
+    "\n",
+    "for N in range(1, 11):\n",
+    "    if b_prev is None:\n",
+    "        init_means = np.ones(N)\n",
+    "    else:\n",
+    "        init_means = np.hstack([b_prev, b_prev[-1]**2 / b_prev[-2]])[:N]\n",
+    "    init_sigmas = np.ones_like(init_means)\n",
+    "    a_ls, b_ls, _ = fit_exp_sum(N, x, w, f, method='de_ls', compiled=False,\n",
+    "                                max_gen=100, pop_size=20,\n",
+    "                                de_mean=init_means, de_sigma=init_sigmas)\n",
+    "    target = f(x)\n",
+    "    obj, grad, hess = _prepare_numpy_funcs(x, target, w, N, newton=True)\n",
+    "    params0 = np.concatenate([a_ls, np.log(b_ls)])\n",
+    "    params_opt, _ = newton_with_line_search(params0, obj, grad, hess,\n",
+    "                                           max_iter=100, compiled=False)\n",
+    "    a_prev = np.exp(params_opt[:N])\n",
+    "    b_prev = np.exp(params_opt[N:])\n",
+    "    def approx(t, a=a_prev, b=b_prev):\n",
+    "        return np.sum(a[:, None] * np.exp(-b[:, None] * t[None, :]**2), axis=0)\n",
+    "    err = l2_error(f, approx, x, w)\n",
+    "    errors.append(err)\n",
+    "\n",
+    "plt.figure(figsize=(6,4))\n",
+    "plt.semilogy(range(1, 11), errors, marker='o')\n",
+    "plt.xlabel('N')\n",
+    "plt.ylabel('L2 error')\n",
+    "plt.title('Convergence of de_ls + Newton fit')\n",
+    "plt.grid(True)\n",
+    "plt.tight_layout()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a nocompile demo notebook illustrating convergence when fitting `exp(-d)`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841af5a28c88323b55ed54539a4ac97