### PR TITLE
Fix de_ls exponentiation handling

### DIFF
--- a/src/kl_decomposition/kernel_fit.py
+++ b/src/kl_decomposition/kernel_fit.py
@@ -546,9 +546,10 @@ def fit_exp_sum(
     else:
         raise ValueError(f"Unknown method: {method}")
 
-    a = np.exp(params[:n_terms])
-    b = np.exp(params[n_terms:])
     if method == "de_ls":
         a = params[:n_terms]
         b = params[n_terms:]
+    else:
+        a = np.exp(params[:n_terms])
+        b = np.exp(params[n_terms:])
     return a, b, info

--- a/tests/test_kernel_fit.py
+++ b/tests/test_kernel_fit.py
@@ -48,6 +48,22 @@ class TestKernelFit(unittest.TestCase):
         self.assertEqual(len(b), 2)
         self.assertLess(info.best_score, 1e-3)
 
+    def test_de_ls_nocompile(self):
+        x, w = rectangle_rule(0.0, 2.0, 30)
+        f = lambda t: 2.0 * np.exp(-3.0 * t**2) + 0.5 * np.exp(-1.0 * t**2)
+        a, b, _ = fit_exp_sum(
+            2,
+            x,
+            w,
+            f,
+            method="de_ls",
+            compiled=False,
+            max_gen=5,
+            pop_size=10,
+        )
+        self.assertTrue(np.all(np.isfinite(a)))
+        self.assertTrue(np.all(np.isfinite(b)))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- avoid exponentiation of parameters when using `de_ls`
- test `de_ls` with compiled mode off to ensure finite coefficients

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841b3f3b3b08323aa265a380bb06a8b