### PR TITLE
Add Galerkin block assembly utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ For each exponential term we form the 1-D block
 
 using shifted, $L^{2}$-orthonormal Legendre polynomials $\phi^{(j)}_{i}$ so that the mass matrix is the identity .
 
+Example usage::
+
+    from kl_decomposition import assemble_block
+    A = assemble_block((0.0, 1.0), b=1.0, n=3)
+
 #### 2.1 Fast quadrature for very large $b_k$
 
 The integrals  

--- a/notebooks/assembly_demo.ipynb
+++ b/notebooks/assembly_demo.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Galerkin block assembly"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import sys\nfrom pathlib import Path\nsys.path.insert(0, str(Path('..') / 'src'))\nfrom kl_decomposition import assemble_block\nA = assemble_block((0.0, 1.0), b=2.0, n=3)\nprint(A)"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/kl_decomposition/__init__.py
+++ b/src/kl_decomposition/__init__.py
@@ -10,6 +10,7 @@ from .kernel_fit import (
     newton_with_line_search,
     bisection_line_search,
 )
+from .galerkin import assemble_block
 
 __all__ = [
     "rectangle_rule",
@@ -20,4 +21,5 @@ __all__ = [
     "NewtonStats",
     "newton_with_line_search",
     "bisection_line_search",
+    "assemble_block",
 ]

--- a/src/kl_decomposition/galerkin.py
+++ b/src/kl_decomposition/galerkin.py
@@ -1,0 +1,47 @@
+"""Assembly of 1-D Galerkin blocks."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.polynomial.legendre import legval
+
+from .kernel_fit import gauss_legendre_rule
+
+__all__ = ["assemble_block"]
+
+
+def _legendre_phi(i: int, x: np.ndarray, a: float, b: float) -> np.ndarray:
+    """Evaluate shifted, L2-orthonormal Legendre polynomial."""
+    u = 2.0 * (x - a) / (b - a) - 1.0
+    return np.sqrt((2 * i + 1) / (b - a)) * legval(u, [0.0] * i + [1.0])
+
+
+def assemble_block(interval: tuple[float, float], coeff_b: float, n: int, *, quad_order: int = 40) -> np.ndarray:
+    """Assemble a single Galerkin block.
+
+    Parameters
+    ----------
+    interval : tuple of float
+        Integration limits ``(a, b)``.
+    coeff_b : float
+        Coefficient of ``(x - y)^2`` in the Gaussian kernel ``exp(-b (x - y)^2)``.
+    n : int
+        Number of Legendre polynomials ``\phi_i``.
+    quad_order : int, optional
+        Order of the Gauss--Legendre quadrature.
+
+    Returns
+    -------
+    ndarray
+        ``n \times n`` Galerkin matrix ``A`` with
+        ``A[i, j] = \int_a^b \int_a^b e^{-b (x - y)^2} \phi_i(y) \phi_j(x) dy dx``.
+    """
+    a, b_ = interval
+    x, w = gauss_legendre_rule(a, b_, quad_order)
+
+    phi = np.array([_legendre_phi(i, x, a, b_) for i in range(n)])
+    weighted_phi = phi * w
+
+    K = np.exp(-coeff_b * (x[:, None] - x[None, :]) ** 2)
+    A = weighted_phi @ K @ weighted_phi.T
+    return A

--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -1,0 +1,25 @@
+import unittest
+import numpy as np
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+from kl_decomposition import assemble_block
+
+
+class TestAssembly(unittest.TestCase):
+    def test_zero_b(self):
+        A = assemble_block((0.0, 1.0), 0.0, 3)
+        expected = np.zeros((3, 3))
+        expected[0, 0] = 1.0
+        self.assertTrue(np.allclose(A, expected, atol=1e-12))
+
+    def test_positive_b(self):
+        A = assemble_block((0.0, 1.0), 1.0, 3)
+        self.assertTrue(np.allclose(A, A.T, atol=1e-12))
+        eigs = np.linalg.eigvalsh(A)
+        self.assertTrue(np.all(eigs > 0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `assemble_block` for 1-D Galerkin matrices
- expose the new function in the package
- document usage in README
- provide unit tests for block assembly
- add a small demo notebook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841ba46a3688323a236fbeb9f70174e