### PR TITLE
Add JAX compiled sorted DE solver

### DIFF
--- a/notebooks/de_newton_sorted_jit_demo.ipynb
+++ b/notebooks/de_newton_sorted_jit_demo.ipynb
@@ -1,0 +1,52 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Differential evolution with sorted Newton step (JAX compiled)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "from pathlib import Path\n",
+    "sys.path.insert(0, str(Path('..') / 'src'))\n",
+    "from kl_decomposition import rectangle_rule\n",
+    "from kl_decomposition.kernel_fit import fit_exp_sum_sorted\n",
+    "import numpy as np\n",
+    "\n",
+    "x, w = rectangle_rule(0.0, 2.0, 50)\n",
+    "f = lambda t: np.exp(-t)\n",
+    "a, b, info = fit_exp_sum_sorted(2, x, w, f, max_gen=20, pop_size=20, compiled=True)\n",
+    "print('a:', a)\n",
+    "print('b:', b)\n",
+    "print('best_score:', info.best_score)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_kernel_fit.py
+++ b/tests/test_kernel_fit.py
@@ -80,6 +80,22 @@ class TestKernelFit(unittest.TestCase):
         self.assertEqual(len(a), 1)
         self.assertEqual(len(b), 1)
 
+    def test_sorted_newton_compiled(self):
+        x, w = rectangle_rule(0.0, 1.0, 20)
+        f = lambda t: np.exp(-2.0 * t**2)
+        a, b, _ = fit_exp_sum_sorted(
+            1,
+            x,
+            w,
+            f,
+            max_gen=5,
+            pop_size=10,
+            n_newton=2,
+            compiled=True,
+        )
+        self.assertEqual(len(a), 1)
+        self.assertEqual(len(b), 1)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow JAX compiled objective for sorted differential evolution
- implement differential evolution routine that sorts parameters before refinement
- expose gradient tolerance in Newton solver
- add notebook demonstrating compiled sorted fit
- test compiled version

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a20372508323a4722e3cb4e7dd7f