### PR TITLE
Integrate fast Duffy assembly

### DIFF
--- a/notebooks/assembly_demo.ipynb
+++ b/notebooks/assembly_demo.ipynb
@@ -6,13 +6,26 @@
    "source": "# Galerkin block assembly"
   },
   {
+  "cell_type": "code",
+  "execution_count": null,
+  "metadata": {},
+  "outputs": [],
+  "source": "import sys\nfrom pathlib import Path\nsys.path.insert(0, str(Path('..') / 'src'))\nfrom kl_decomposition import assemble_block\nA = assemble_block((0.0, 1.0), b=2.0, n=3)\nprint(A)"
+  }
+ ,
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Fast assembly with Duffy mapping"
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": "import sys\nfrom pathlib import Path\nsys.path.insert(0, str(Path('..') / 'src'))\nfrom kl_decomposition import assemble_block\nA = assemble_block((0.0, 1.0), b=2.0, n=3)\nprint(A)"
+   "source": "import numpy as np\nfrom kl_decomposition import assemble_duffy, assemble_gauss2d\nA_duf = assemble_duffy(f=100.0, degree=3, quad=40)\nA_ref = assemble_gauss2d(f=100.0, degree=3, quad=1000)\nerr = np.linalg.norm(A_duf - A_ref)\nprint('Frobenius error vs reference:', err)"
   }
- ],
+],
  "metadata": {
   "kernelspec": {
    "display_name": "Python",

--- a/src/kl_decomposition/__init__.py
+++ b/src/kl_decomposition/__init__.py
@@ -11,7 +11,13 @@ from .kernel_fit import (
     newton_with_line_search,
     bisection_line_search,
 )
-from .galerkin import assemble_block
+from .galerkin import (
+    assemble_block,
+    assemble_duffy,
+    assemble_gauss2d,
+    assemble_rectangle,
+    convergence_vs_ref,
+)
 
 __all__ = [
     "rectangle_rule",
@@ -24,4 +30,8 @@ __all__ = [
     "newton_with_line_search",
     "bisection_line_search",
     "assemble_block",
+    "assemble_duffy",
+    "assemble_gauss2d",
+    "assemble_rectangle",
+    "convergence_vs_ref",
 ]

--- a/src/kl_decomposition/galerkin.py
+++ b/src/kl_decomposition/galerkin.py
@@ -3,17 +3,33 @@
 from __future__ import annotations
 
 import numpy as np
-from numpy.polynomial.legendre import legval
+from numpy.polynomial.legendre import Legendre, legval
 
 from .kernel_fit import gauss_legendre_rule
 
-__all__ = ["assemble_block"]
+__all__ = [
+    "assemble_block",
+    "assemble_duffy",
+    "assemble_gauss2d",
+    "assemble_rectangle",
+    "convergence_vs_ref",
+]
 
 
 def _legendre_phi(i: int, x: np.ndarray, a: float, b: float) -> np.ndarray:
     """Evaluate shifted, L2-orthonormal Legendre polynomial."""
     u = 2.0 * (x - a) / (b - a) - 1.0
     return np.sqrt((2 * i + 1) / (b - a)) * legval(u, [0.0] * i + [1.0])
+
+
+def leg_vals(n_max: int, x: np.ndarray) -> np.ndarray:
+    """Values of orthonormal Legendre polynomials on ``[0, 1]``."""
+    t = 2.0 * x - 1.0
+    vals = np.empty((n_max, x.size))
+    pref = 1.0 / np.sqrt(2.0)
+    for n in range(n_max):
+        vals[n] = np.sqrt(2 * n + 1) * pref * Legendre.basis(n)(t)
+    return vals
 
 
 def assemble_block(interval: tuple[float, float], coeff_b: float, n: int, *, quad_order: int = 40) -> np.ndarray:
@@ -45,3 +61,64 @@ def assemble_block(interval: tuple[float, float], coeff_b: float, n: int, *, qua
     K = np.exp(-coeff_b * (x[:, None] - x[None, :]) ** 2)
     A = weighted_phi @ K @ weighted_phi.T
     return A
+
+
+def assemble_duffy(f: float, degree: int, quad: int,
+                   gx: float = 4.0, gy: float | None = None) -> np.ndarray:
+    """Duffy-split assembly on ``[0, 1]`` with polynomial stretching."""
+    if gy is None:
+        gy = gx
+
+    xi, wx = np.polynomial.legendre.leggauss(quad)
+    xi = 0.5 * (xi + 1.0)
+    wx = 0.5 * wx
+    X, Y = np.meshgrid(xi, xi, indexing="ij")
+    W = np.outer(wx, wx)
+
+    u = X ** gx
+    v = Y ** gy
+    J = gx * gy * X ** (gx - 1) * Y ** (gy - 1)
+    Khat = J * u * np.exp(-f * (u * v) ** 2)
+
+    x1, y1 = u, (1.0 - v) * u
+    x2, y2 = 1.0 - u, (v - 1.0) * u + 1.0
+
+    phix1 = leg_vals(degree, x1.ravel()).reshape(degree, *x1.shape)
+    phiy1 = leg_vals(degree, y1.ravel()).reshape(degree, *y1.shape)
+    phix2 = leg_vals(degree, x2.ravel()).reshape(degree, *x2.shape)
+    phiy2 = leg_vals(degree, y2.ravel()).reshape(degree, *y2.shape)
+
+    weight = W * Khat
+    A = (
+        np.einsum("mn,imn,jmn->ij", weight, phix1, phiy1)
+        + np.einsum("mn,imn,jmn->ij", weight, phix2, phiy2)
+    )
+    return A
+
+
+def assemble_gauss2d(f: float, degree: int, quad: int) -> np.ndarray:
+    """Direct tensor-product Gauss--Legendre on ``[0, 1]``."""
+    x, wx = np.polynomial.legendre.leggauss(quad)
+    x = 0.5 * (x + 1.0)
+    wx = 0.5 * wx
+    phi = leg_vals(degree, x)
+    K = np.exp(-f * (x[:, None] - x[None, :]) ** 2)
+    return phi @ (K * (wx[:, None] * wx[None, :])) @ phi.T
+
+
+def assemble_rectangle(f: float, degree: int, m: int) -> np.ndarray:
+    """Midpoint rectangle rule on ``[0, 1]``²."""
+    x = (np.arange(m) + 0.5) / m
+    dx = 1.0 / m
+    phi = leg_vals(degree, x)
+    K = np.exp(-f * (x[:, None] - x[None, :]) ** 2)
+    return phi @ (K * dx * dx) @ phi.T
+
+
+def convergence_vs_ref(
+    f: float, degree: int, g: float, quad_list: list[int], quad_ref: int
+) -> tuple[list[int], list[float]]:
+    """Convergence study helper for :func:`assemble_duffy`."""
+    A_ref = assemble_gauss2d(f, degree, quad_ref)
+    errs = [np.linalg.norm(assemble_duffy(f, degree, q, g) - A_ref) for q in quad_list]
+    return quad_list, errs


### PR DESCRIPTION
## Summary
- add Duffy-based assembly and helpers
- expose new routines in package
- update assembly demo notebook with example of `assemble_duffy`

## Testing
- `pip install numpy matplotlib jax jaxlib --quiet`
- `pip install numba --quiet`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842df3fd7b483238046f0c428ec3f97