### PR TITLE
Fix Legendre normalisation for consistent matrix assembly

### DIFF
--- a/src/kl_decomposition/galerkin.py
+++ b/src/kl_decomposition/galerkin.py
@@ -26,9 +26,8 @@ def leg_vals(n_max: int, x: np.ndarray) -> np.ndarray:
     """Values of orthonormal Legendre polynomials on ``[0, 1]``."""
     t = 2.0 * x - 1.0
     vals = np.empty((n_max, x.size))
-    pref = 1.0 / np.sqrt(2.0)
     for n in range(n_max):
-        vals[n] = np.sqrt(2 * n + 1) * pref * Legendre.basis(n)(t)
+        vals[n] = np.sqrt(2 * n + 1) * Legendre.basis(n)(t)
     return vals
 
 


### PR DESCRIPTION
## Summary
- correct normalisation of Legendre polynomials used in 2‑D assembly routines

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842f1ad7ddc832395fada8c658575df