### PR TITLE
Optimize Galerkin assembly for parity

### DIFF
--- a/tests/test_assembly.py
+++ b/tests/test_assembly.py
@@ -4,7 +4,12 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
-from kl_decomposition import assemble_block
+from kl_decomposition import (
+    assemble_block,
+    assemble_duffy,
+    assemble_gauss2d,
+    assemble_rectangle,
+)
 
 
 class TestAssembly(unittest.TestCase):
@@ -19,6 +24,16 @@ class TestAssembly(unittest.TestCase):
         self.assertTrue(np.allclose(A, A.T, atol=1e-12))
         eigs = np.linalg.eigvalsh(A)
         self.assertTrue(np.all(eigs > 0))
+
+    def test_methods_agree(self):
+        f = 0.7
+        degree = 4
+        q = 30
+        A1 = assemble_duffy(f, degree, q)
+        A2 = assemble_gauss2d(f, degree, q)
+        A3 = assemble_rectangle(f, degree, 300)
+        self.assertTrue(np.allclose(A1, A2, atol=1e-8))
+        self.assertTrue(np.allclose(A1, A3, atol=1e-5))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- speed up assembly routines by computing even and odd blocks separately
- compare assembly methods in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fd81e39483239f23eb6ca13414dc