### PR TITLE
Add analytic eigen-decomposition for exponential kernel

### DIFF
--- a/notebooks/exponential_kernel_eig.ipynb
+++ b/notebooks/exponential_kernel_eig.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fb6221da",
+   "metadata": {},
+   "source": [
+    "# Exponential kernel eigen-decomposition"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9586e54e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kl_decomposition import exp_kernel_eigen\n",
+    "alpha = 2.0\n",
+    "vals_c, freqs_c, vals_s, freqs_s = exp_kernel_eigen(alpha, L=1.0, n_cos=3, n_sin=3)\n",
+    "print('cos eigenvalues:', vals_c)\n",
+    "print('sin eigenvalues:', vals_s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a63fd410",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "x = np.linspace(0,1,200)\n",
+    "plt.figure()\n",
+    "for w in freqs_c:\n",
+    "    plt.plot(x, np.sqrt(2)*np.cos(w*x), label=f'cos w={w:.2f}')\n",
+    "for w in freqs_s:\n",
+    "    plt.plot(x, np.sqrt(2)*np.sin(w*x), '--', label=f'sin w={w:.2f}')\n",
+    "plt.legend()\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {},
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/kl_decomposition/__init__.py
+++ b/src/kl_decomposition/__init__.py
@@ -18,6 +18,7 @@ from .galerkin import (
     assemble_rectangle,
     convergence_vs_ref,
 )
+from .exp_kernel import exp_kernel_eigen
 
 __all__ = [
     "rectangle_rule",
@@ -34,4 +35,5 @@ __all__ = [
     "assemble_gauss2d",
     "assemble_rectangle",
     "convergence_vs_ref",
+    "exp_kernel_eigen",
 ]

--- a/src/kl_decomposition/exp_kernel.py
+++ b/src/kl_decomposition/exp_kernel.py
@@ -1,0 +1,77 @@
+"""Eigen-decomposition of the 1-D exponential kernel.
+
+This module provides helper routines for computing the analytic eigenpairs
+of the kernel
+
+    K(x, y) = exp(-alpha * |x - y|),  0 <= x, y <= L.
+
+The eigenfunctions come in cosine (Neumann-like) and sine (Dirichlet-like)
+families.  The corresponding frequencies ``omega`` are solutions of
+
+* ``tan(omega * L) =  omega / alpha``     (cosine family)
+* ``tan(omega * L) = -alpha / omega``    (sine family)
+
+and the eigenvalues are ``lambda = 2 * alpha / (alpha**2 + omega**2)``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.optimize import brentq
+from typing import Callable
+
+__all__ = ["exp_kernel_eigen"]
+
+
+def _find_roots(func: Callable[[float], float], intervals: list[tuple[float, float]]) -> list[float]:
+    roots = []
+    for a, b in intervals:
+        try:
+            root = brentq(func, a, b)
+            roots.append(root)
+        except ValueError:
+            continue
+    return roots
+
+
+def exp_kernel_eigen(alpha: float, L: float = 1.0, n_cos: int = 3, n_sin: int = 3):
+    """Return eigenvalues and frequencies of ``exp(-alpha*|x-y|)`` on ``[0, L]``.
+
+    Parameters
+    ----------
+    alpha : float
+        Decay parameter of the kernel.
+    L : float, optional
+        Length of the interval ``[0, L]``.
+    n_cos, n_sin : int, optional
+        Number of cosine and sine modes to compute.
+
+    Returns
+    -------
+    cos_vals : ndarray
+        Eigenvalues associated with the cosine family.
+    cos_freqs : ndarray
+        Frequencies ``omega`` of the cosine eigenfunctions.
+    sin_vals : ndarray
+        Eigenvalues associated with the sine family.
+    sin_freqs : ndarray
+        Frequencies ``omega`` of the sine eigenfunctions.
+    """
+    eps = 1e-6
+    cos_intervals = [
+        (n * np.pi + eps, (n + 0.5) * np.pi - eps) for n in range(n_cos)
+    ]
+    sin_intervals = [
+        ((n + 0.5) * np.pi + eps, (n + 1) * np.pi - eps) for n in range(n_sin)
+    ]
+
+    f_cos = lambda w: np.tan(w * L) - w / alpha
+    f_sin = lambda w: np.tan(w * L) + alpha / w
+
+    cos_freqs = np.array(_find_roots(f_cos, cos_intervals))
+    sin_freqs = np.array(_find_roots(f_sin, sin_intervals))
+
+    cos_vals = 2 * alpha / (alpha**2 + cos_freqs**2)
+    sin_vals = 2 * alpha / (alpha**2 + sin_freqs**2)
+
+    return cos_vals, cos_freqs, sin_vals, sin_freqs

--- a/src/kl_decomposition/kernel_fit.py
+++ b/src/kl_decomposition/kernel_fit.py
@@ -27,7 +27,20 @@ from .orthopoly import gauss_legendre_rule
 from numpy.typing import ArrayLike
 import jax
 import jax.numpy as jnp
-import numba as nb
+try:
+    import numba as nb
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    class _NB:
+        def njit(self, *args, **kwargs):
+            if args and callable(args[0]):
+                return args[0]
+
+            def wrapper(func):
+                return func
+
+            return wrapper
+
+    nb = _NB()
 
 __all__ = [
     "rectangle_rule",


### PR DESCRIPTION
## Summary
- implement solver for eigenvalues of the 1‑D exponential kernel
- expose new helper in package API
- make numba optional for kernel fitting
- add notebook demonstrating the eigenpairs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430bcfbc688323879dc939ee5148f5